### PR TITLE
Allow build number to be passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ERP Get Build
 Download an Enterprise Reference Platform (ERP) release.
 
 By default, this role will discover the latest staging ERP build from jenkins,
-set 'erp_latest_build' number, and download the build to ./builds/staging/.
+set 'erp_build_number' number, and download the build to ./builds/staging/.
 
 Role Variables
 --------------
@@ -14,12 +14,13 @@ In:
 | variable | description | default
 |----------|-------------|---------
 | erp_debian_installer_environment | [staging|release] | staging
+| erp_build_number | ERP build to retrieve. | Defaults to false, in which case it will be set to the latest build number.
 
 Out:
 
 | variable | description | example
 |----------|-------------|---------
-| erp_latest_build | Latest build number, based on debian_installer_environment | 430
+| erp_build_number | Latest build number, based on debian_installer_environment | 430
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@
 # 'release'.
 erp_debian_installer_environment: staging
 
+# If unset, use the latest build
+erp_build_number: false
+
 erp_debian_installer_jenkins_urls:
   staging: "https://ci.linaro.org/view/reference-platform/job/96boards-reference-debian-installer-staging/api/json"
   release: "https://ci.linaro.org/view/reference-platform/job/96boards-reference-debian-installer/api/json"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,20 +3,26 @@
   uri:
     url: "{{erp_debian_installer_jenkins_urls[erp_debian_installer_environment]}}"
   register: jenkins_build_info
+  when: not erp_build_number
 - set_fact:
-    erp_latest_build: "{{jenkins_build_info['json']['lastCompletedBuild']['number']}}"
+    erp_build_number: "{{jenkins_build_info['json']['lastCompletedBuild']['number']}}"
+  when: not erp_build_number
+
+# For backward compatibility
+- set_fact:
+    erp_latest_build: "{{erp_build_number}}"
 
 - debug:
-    msg: "Latest debian installer {{erp_debian_installer_environment}} build is {{erp_latest_build}}"
+    msg: "Using debian installer {{erp_debian_installer_environment}} build {{erp_build_number}}"
 
 - name: Create local builds directory
   file:
-    path: "./builds/debian-{{erp_debian_installer_environment}}/{{erp_latest_build}}"
+    path: "./builds/debian-{{erp_debian_installer_environment}}/{{erp_build_number}}"
     state: directory
 - name: Download build locally
   get_url:
-    url: "{{erp_debian_installer_download_urls[erp_debian_installer_environment]}}/{{erp_latest_build}}/debian-installer/arm64/{{item}}"
-    dest: "./builds/debian-{{erp_debian_installer_environment}}/{{erp_latest_build}}/{{item}}"
+    url: "{{erp_debian_installer_download_urls[erp_debian_installer_environment]}}/{{erp_build_number}}/debian-installer/arm64/{{item}}"
+    dest: "./builds/debian-{{erp_debian_installer_environment}}/{{erp_build_number}}/{{item}}"
   with_items:
     - "initrd.gz"
     - "linux"


### PR DESCRIPTION
This allows usage 'ansible-playbook -e erp_build_number=450 main.yml'.

Preserve erp_latest_build as an output for backward compatibility, but
change all documentation and references to erp_build_number.

Signed-off-by: Dan Rue <dan.rue@linaro.org>