### PR TITLE
Implement 'stable' branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ In:
 
 | variable | description | default
 |----------|-------------|---------
-| erp_debian_installer_environment | [staging|release] | staging
+| erp_debian_installer_environment | [staging|stable] | staging
 | erp_build_number | ERP build to retrieve. | Defaults to false, in which case it will be set to the latest build number.
 
 Out:
 
 | variable | description | example
 |----------|-------------|---------
-| erp_build_number | Latest build number, based on debian_installer_environment | 430
+| erp_build_number | Latest build number, based on erp_debian_installer_environment | 430
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,9 +9,9 @@ erp_build_number: false
 
 erp_debian_installer_jenkins_urls:
   staging: "https://ci.linaro.org/view/reference-platform/job/96boards-reference-debian-installer-staging/api/json"
-  release: "https://ci.linaro.org/view/reference-platform/job/96boards-reference-debian-installer/api/json"
+  stable: "https://ci.linaro.org/view/reference-platform/job/96boards-reference-debian-installer/api/json"
 
 erp_debian_installer_download_urls:
   staging: "http://builds.96boards.org/snapshots/reference-platform/components/debian-installer-staging/"
-  release: "http://builds.96boards.org/snapshots/reference-platform/components/debian-installer/"
+  stable: "http://builds.96boards.org/snapshots/reference-platform/components/debian-installer/"
 


### PR DESCRIPTION
Change as-of-yet unused name 'release' to more appropriate 'stable', to
match the jenkins build and apt repo names