### PR TITLE
Get latest build number directly from build server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,10 +7,13 @@ erp_debian_installer_environment: staging
 # If unset, use the latest build
 erp_build_number: false
 
-erp_debian_installer_jenkins_urls:
-  staging: "https://ci.linaro.org/view/reference-platform/job/96boards-reference-debian-installer-staging/api/json"
-  stable: "https://ci.linaro.org/view/reference-platform/job/96boards-reference-debian-installer/api/json"
+# Used to discover available builds and set erp_build_number, when it's not
+# explicitly set
+erp_debian_installer_download_urls_api:
+  staging: "http://builds.96boards.org/api/ls/snapshots/reference-platform/components/debian-installer-staging/"
+  stable: "http://builds.96boards.org/api/ls/snapshots/reference-platform/components/debian-installer/"
 
+# Used to download builds
 erp_debian_installer_download_urls:
   staging: "http://builds.96boards.org/snapshots/reference-platform/components/debian-installer-staging/"
   stable: "http://builds.96boards.org/snapshots/reference-platform/components/debian-installer/"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,12 @@
 ---
-- name: Get latest build number from Jenkins
+- name: Get latest build number from build server
   uri:
-    url: "{{erp_debian_installer_jenkins_urls[erp_debian_installer_environment]}}"
-  register: jenkins_build_info
+    url: "{{erp_debian_installer_download_urls_api[erp_debian_installer_environment]}}"
+  register: builds_available
   when: not erp_build_number
 - set_fact:
-    erp_build_number: "{{jenkins_build_info['json']['lastCompletedBuild']['number']}}"
+    # The [0] entry is 'latest', the [1] is the most recent build number.
+    erp_build_number: "{{builds_available['json']['files'][1]['name']}}"
   when: not erp_build_number
 
 # For backward compatibility


### PR DESCRIPTION
This removes a dependency on jenkins, as well as a race condition in the
event that a jenkins build has started but has not yet been uploaded.

Hat tip to Chase for pointing out the /api/ls/ trick on
builds.96boards.org!