### PR TITLE
Add support for generic installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ ERP Get Build
 
 Download an Enterprise Reference Platform (ERP) release.
 
-By default, this role will discover the latest staging ERP build from jenkins,
-set 'erp_build_number' number, and download the build to ./builds/staging/.
+By default, this role will discover the latest staging ERP build by qeurying
+'erp_installer_download_urls_api', set 'erp_build_number' number, and download the build
+to ./builds/debian-staging/.
 
 Role Variables
 --------------
@@ -13,8 +14,12 @@ In:
 
 | variable | description | default
 |----------|-------------|---------
-| erp_debian_installer_environment | [staging\|stable] | staging
-| erp_build_number | ERP build to retrieve. | Defaults to false, in which case it will be set to the latest build number.
+| erp_installer_distro | [debian\|centos] | debian
+| erp_installer_environment | [staging\|stable] | staging
+| erp_build_number | ERP build to retrieve | Defaults to false, in which case it will be set to the latest build number
+| erp_installer_download_urls_api | Used to discover available builds and set erp_build_number | http://snapshots.linaro.org/api/ls/96boards/reference-platform/components/debian-installer-staging/
+| erp_installer_download_urls | Used to download build | http://snapshots.linaro.org/96boards/reference-platform/components/debian-installer-staging/
+| erp_image_remote_paths | ERP build images to retrieve | kernel: "debian-installer/arm64/linux", initrd: "debian-installer/arm64/initrd.gz"
 
 Out:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,21 +1,24 @@
 ---
-
-# Which debian installer to use. Defaults to staging, but may also be
-# 'release'.
-erp_debian_installer_environment: staging
+# Which installer to use. Defaults to debian staging, but may also be other builds
+erp_installer_distro: debian
+erp_installer_environment: staging
 
 # If unset, use the latest build
 erp_build_number: false
 
 # Used to discover available builds and set erp_build_number, when it's not
 # explicitly set
-erp_debian_installer_download_urls_api:
+erp_installer_download_urls_api:
   staging: "http://snapshots.linaro.org/api/ls/96boards/reference-platform/components/debian-installer-staging/"
   stable: "http://snapshots.linaro.org/api/ls/96boards/reference-platform/components/debian-installer/"
 
 
 # Used to download builds
-erp_debian_installer_download_urls:
+erp_installer_download_urls:
   staging: "http://snapshots.linaro.org/96boards/reference-platform/components/debian-installer-staging/"
   stable: "http://snapshots.linaro.org/96boards/reference-platform/components/debian-installer/"
 
+# Used to download build images
+erp_image_remote_paths:
+  kernel: "debian-installer/arm64/linux"
+  initrd: "debian-installer/arm64/initrd.gz"

--- a/tasks/get-build.yml
+++ b/tasks/get-build.yml
@@ -1,9 +1,10 @@
 ---
 - name: Get latest build number from build server
   uri:
-    url: "{{erp_debian_installer_download_urls_api[erp_debian_installer_environment]}}"
+    url: "{{erp_installer_download_urls_api[erp_installer_environment]}}"
   register: builds_available
   when: not erp_build_number
+
 - set_fact:
     # The [0] entry is 'latest', the [1] is the most recent build number.
     erp_build_number: "{{builds_available['json']['files'][1]['name']}}"
@@ -14,28 +15,28 @@
     erp_latest_build: "{{erp_build_number}}"
 
 - debug:
-    msg: "Using debian installer {{erp_debian_installer_environment}} build {{erp_build_number}}"
+    msg: "Using {{erp_installer_distro}} {{erp_installer_environment}} build {{erp_build_number}}"
 
 - name: Create local builds directory
   file:
-    path: "./builds/debian-{{erp_debian_installer_environment}}/{{erp_build_number}}"
+    path: "./builds/{{erp_installer_distro}}-{{erp_installer_environment}}/{{erp_build_number}}"
     state: directory
 - name: Save download paths
   set_fact:
     erp_image_paths:
-      kernel: "./builds/debian-{{erp_debian_installer_environment}}/{{erp_build_number}}/linux"
-      initrd: "./builds/debian-{{erp_debian_installer_environment}}/{{erp_build_number}}/initrd.gz"
+      kernel: "./builds/{{erp_installer_distro}}-{{erp_installer_environment}}/{{erp_build_number}}/{{erp_image_remote_paths['kernel'] | basename}}"
+      initrd: "./builds/{{erp_installer_distro}}-{{erp_installer_environment}}/{{erp_build_number}}/{{erp_image_remote_paths['initrd'] | basename}}"
 - name: Download build locally
   get_url:
-    url: "{{erp_debian_installer_download_urls[erp_debian_installer_environment]}}/{{erp_build_number}}/debian-installer/arm64/{{item}}"
-    dest: "./builds/debian-{{erp_debian_installer_environment}}/{{erp_build_number}}/{{item}}"
+    url: "{{erp_installer_download_urls[erp_installer_environment]}}/{{erp_build_number}}/{{erp_image_remote_paths[item]}}"
+    dest: "./builds/{{erp_installer_distro}}-{{erp_installer_environment}}/{{erp_build_number}}/{{erp_image_remote_paths[item] | basename}}"
   with_items:
-    - "initrd.gz"
-    - "linux"
+    - "kernel"
+    - "initrd"
 
 - name: Set facts for mr-provisioner
   set_fact:
-    mr_provisioner_kernel_description: "debian-installer {{erp_debian_installer_environment}} build {{erp_build_number}}"
-    mr_provisioner_initrd_description: "debian-installer {{erp_debian_installer_environment}} build {{erp_build_number}}"
+    mr_provisioner_kernel_description: "{{erp_installer_distro}}-installer {{erp_installer_environment}} build {{erp_build_number}}"
+    mr_provisioner_initrd_description: "{{erp_installer_distro}}-installer {{erp_installer_environment}} build {{erp_build_number}}"
     mr_provisioner_kernel_path: "{{erp_image_paths['kernel']}}"
     mr_provisioner_initrd_path: "{{erp_image_paths['initrd']}}"


### PR DESCRIPTION
Introduce the following new vars to support generic installers.
    * erp_installer_distro
    * erp_image_remote_paths

Signed-off-by: Chase Qi <chase.qi@linaro.org>